### PR TITLE
Add PythonBrasil[13] info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ## Slides e materiais das conferências Python pelo Brasil
 
 
+### [Python Brasil [13]](/pythonbrasil-13/README.md)
+- Belo Horizonte, MG
+- 06 a 11 de Outubro de 2017
+- [2017.pythonbrasil.org.br](http://2017.pythonbrasil.org.br)
+
 ### [Python Brasil [12]](/pythonbrasil-12/README.md)
 - Florianópolis, SC
 - 13 a 18 de Outubro de 2016

--- a/pythonbrasil-13/README.md
+++ b/pythonbrasil-13/README.md
@@ -1,0 +1,87 @@
+# Atividades ministradas na [Python Brasil [13]](http://2017.pythonbrasil.org.br)
+
+Slides e materiais das palestras e tutoriais ministrados na Python Brasil \[13\] em
+outubro/2017 em Belo Horizonte/MG.
+
+## Palestras
+
+### Dia 6
+
+- **Keynote** - Paola Katherine
+- **Serenata de Amor: Inteligência artificial usando dados abertos governamentais** - Jessica Temporal
+- **Python na Manutenção de mais de 100 mil embarcados** - Tiago Assunção
+- **Como NÃO programar em Python: crimes dolosos e com agravante** - Ryllari Santana
+- **Bots (automatizando tarefas) um funcionário que não reclama!** - Elinaldo Monteiro
+- **Decifrando as Runas dos Anões com Python e Machado de Assis** - Hélio de Meira Lins
+- **A Qualidade do Ecossistema Python - e o que podemos fazer para mantê-la** - Bruno Rocha
+- **GraphQL: nem sempre REST é a melhor alternativa para sua API** - Nicolle Cysneiros
+- **Embalando segredos com Python** - Moisés Guimarães
+- **Big Data com Apache Spark na Globo.com** - Daniela Petruzalek
+- **Plataforma distribuída de Microserviços ou, como a Olist funciona** - Osvaldo Santana
+- **Prevenindo dores de cabeça com linters e checagens automáticas** - Flávio Juvenal
+- **Criando Web Crawlers com Scrapy e Selenium para páginas com Javascript** - Gileno Filho
+- **Python na Infraestrutura MySQL do Facebook** - Artur Rodrigues
+- **Desafios e vantagens do trabalho remoto freelancer Python** - Julio Melanda
+- **Redes Neurais com Python e Scikit** - Bianca Rosa
+- **Keynote** - Manuel Kaufmann
+
+### Dia 7
+
+- **Keynote** - Rodolpho Eckhardt
+- **Agilizando o ciclo de desenvolvimento de software com a ajuda de testes unitários** - Paula Grangeiro
+- **Salvando grandes projetos** - Lais Varejão
+- **Kivy: Python no celular e em vários outros lugares!** - Diego "Dukão" Guimarães
+- **The Walking Dev** - Henrique Bastos
+- **Django Migrations: para entender e perder o medo** - Kátia Nakamura
+- **Descomplicando os mocks** - Douglas Bastos
+- **Concorrência e Paralelismo - Threads, Múltiplos processos e ASYNCIO** - Diogo Martins
+- **Gênero e Número: Python ajudando nas questões de gênero brasileiras** - Álvaro "Turicas" Justen
+- **Python, ciência dos dados e redes sociais: uma combinação poderosa** - Alice Adativa
+- **Generators e Programação Assincrona com Python** - Thomaz Reis
+- **Análise de imagens e machine learning utilizando Python e openCV** - Paula Santos
+- **Python Runtime sem GIL em Golang: Grumpy** - Alan Justino
+- **Keynote** - Allison Kaptur
+
+### Dia 8
+
+- **Padrões Arquiteturais, muito além do MVC** - Darlene Medeiros
+- **Previsão de séries temporais com PyData e Inteligência Artificial** - Rebeca Sarai
+- **Projetos de APIs: O que pensar para APIs Públicas, Microsserviços e SPAs** - Celso Crivelaro
+- **O Flask roubou meu coração** - Talita Rossari
+- **Navegando por grafos com Python** - Bernardo Fontes
+- **Trabalhando com código legado** - Renato Oliveira
+- **Facebook Job Engine (FBJE): a framework for developing scalable workflows in Python** - Navid Sheikhol
+- **O que desenvolvedores deveriam aprender sobre design?** - Débora Correia
+- **Começando com Python - Aprendendo para ensinar, a melhor forma de programar!** - Ana Paula Mendes
+- **PyLadies e Django Girls promovendo a diversidade na tecnologia** - Pyladies Brasil
+- **A Programação Funcional em Python, de forma simples** - Anderson Resende
+- **Provisionamento de redes no data center Globo.com com Python** - Laura Panzariello
+- **O fim de uma era: os desafios de transformar um monolito de 8 anos em microserviços** - Rael Max
+- **Python e tipagem estática** - Carlos Henrique Coêlho
+- **Usando Python e Django para ampliar a democracia digital** - Matheus Souza Fernandes
+- **(Quase) Tudo que você precisa saber sobre tarefas assíncronas** - Filipe Ximenes
+- **Linha de Comando: como ser bem implementada e segura** - Carla Souza
+- **Geometria Computacional de Diferencial com Python e SVG: As Curvas da Bosta** - Ole Peter Smith
+- **Keynote** - Andrew Godwin
+
+## Tutoriais
+
+### Dia 9
+
+- **Django Girls Workshop** - Django Girls
+- **Aprenda Flask criando um CMS e suas extensões. What The Flask?** - Bruno Rocha
+- **Introdução aos Módulos de Análise de Dados** - Letícia Portella e Jessica Temporal
+- **Testes: os primeiros passos** - Roberta Takenaka
+- **Dockerizando suas aplicações Python** - Felipe Morais
+- **Introdução à Raspagem de Dados** - Fernando Masanori
+- **Criando meu primeiro jogo com Python** - Julio Melanda
+
+### Dia 10
+
+- **Curso Básico de Python para Iniciantes** - PyLadies São Paulo
+- **Introdução ao GIT (Escolinha do prof. Samuka)** - Samuel Sampaio
+- **Desenvolva sua Rest API complexa em 1 dia** - Felipe Samuel
+- **APIs Inteligentes com API Star** - Nicolle Cysneiros
+- **Desenvolvimento de um Web Crawler com Python 3** - Gustavo Henrique Nunes
+- **Test Driven Design** - Renato Oliveira e Bernardo Fontes
+- **Capturando dados abertos sem dor de cabeça** - Álvaro "Turicas" Justen

--- a/pythonbrasil-13/README.md
+++ b/pythonbrasil-13/README.md
@@ -44,7 +44,7 @@ outubro/2017 em Belo Horizonte/MG.
 
 ### Dia 8
 
-- **Padrões Arquiteturais, muito além do MVC** - Darlene Medeiros
+- [**Padrões Arquiteturais, muito além do MVC**](padroes_arquiteturais_muito_alem_do_mvc) - [Darlene Medeiros](https://www.linkedin.com/in/darlene-medeiros)
 - **Previsão de séries temporais com PyData e Inteligência Artificial** - Rebeca Sarai
 - **Projetos de APIs: O que pensar para APIs Públicas, Microsserviços e SPAs** - Celso Crivelaro
 - **O Flask roubou meu coração** - Talita Rossari

--- a/pythonbrasil-13/padroes_arquiteturais_muito_alem_do_mvc/README.md
+++ b/pythonbrasil-13/padroes_arquiteturais_muito_alem_do_mvc/README.md
@@ -1,0 +1,35 @@
+Padrões Arquiteturais, muito além do MVC
+===
+#### Darlene Medeiros
+
+Sempre que iniciamos um novo projeto queremos que ele seja perfeito, o código tem que ser bem escrito, com alta coesão, baixo acoplamento, SOLID, KISS, DRY, YAGNI, testes automatizados e padrões de código, mas um ponto que nem sempre refletimos é sobre a estrutura da aplicação.
+Meu objetivo nessa palestra é apresentar alguns padrões arquiteturais (MVC, event-driven, microservices e pipe and filter) em Python, utilizando exemplos de frameworks como Django, Flask e Tornado, e te ajudar a entender como eles funcionam.
+
+---
+
+#### Slides
+
+- [speakerdeck.com/darlene/padroes-arquiteturais-muito-alem-do-mvc-python-brasil-2017-pybr-13](https://speakerdeck.com/darlene/padroes-arquiteturais-muito-alem-do-mvc-python-brasil-2017-pybr-13)
+
+#### Referências
+
+- [martinfowler.com/ieeeSoftware/whoNeedsArchitect.pdf](https://martinfowler.com/ieeeSoftware/whoNeedsArchitect.pdf)
+
+- [enterpriseintegrationpatterns.com/patterns/messaging/toc.html](http://www.enterpriseintegrationpatterns.com/patterns/messaging/toc.html)
+
+- [msdn.microsoft.com/pt-br/library/ff650706.aspx](https://msdn.microsoft.com/pt-br/library/ff650706.aspx)
+
+- [packtpub.com/application-development/software-architecture-python](https://www.packtpub.com/application-development/software-architecture-python)
+
+- [docs.djangoproject.com/en/dev/faq/general/#django-appears-to-be-a-mvc-framework-but-you-call-the-controller-the-view-and-the-view-the-template-how-come-you-don-t-use-the-standard-names](https://docs.djangoproject.com/en/dev/faq/general/#django-appears-to-be-a-mvc-framework-but-you-call-the-controller-the-view-and-the-view-the-template-how-come-you-don-t-use-the-standard-names)
+
+- [en.wikipedia.org/wiki/List_of_software_architecture_styles_and_patterns](https://en.wikipedia.org/wiki/List_of_software_architecture_styles_and_patterns)
+
+- [herbertograca.com/2017/07/28/architectural-styles-vs-architectural-patterns-vs-design-patterns/](https://herbertograca.com/2017/07/28/architectural-styles-vs-architectural-patterns-vs-design-patterns/)
+
+- [slideshare.net/osantana/plataforma-distribuda-de-microservios-ou-como-a-olist-funciona](https://www.slideshare.net/osantana/plataforma-distribuda-de-microservios-ou-como-a-olist-funciona)
+
+#### Contato
+
+- [Github](https://github.com/darlenedms)
+- [LinkedIn](https://www.linkedin.com/in/darlene-medeiros)


### PR DESCRIPTION
Criei a pasta da Python Brasil [13] com a listagem de palestras e tutoriais. Além disso, incluí as informações da minha palestra.